### PR TITLE
Windows compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,5 +44,5 @@ ENV NO_AT_BRIDGE=1
 WORKDIR /rover_ws
 COPY ./docker/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
-
+WORKDIR /
+ENTRYPOINT [ "bash", "entrypoint.sh" ]


### PR DESCRIPTION
Forces line endings to LF to avoid touched files on Windows becoming CRLF in docker, and defines the bash shell for running the entrypoint.